### PR TITLE
[TSK-73] 目的駅ルーレットの候補をミッション駅のみに絞る

### DIFF
--- a/src/app/events/v03/[eventCode]/operation/tools/page.tsx
+++ b/src/app/events/v03/[eventCode]/operation/tools/page.tsx
@@ -117,7 +117,7 @@ const ToolsPage: React.FC = (): React.JSX.Element => {
                 {!isLoading && !isInitDataLoading && !error && !contextError && (
                     <>
                         <RegisterGoalStationsFormV3
-                            stations={stations.filter((station) => station.stationType == StationType.mission)}
+                            stations={stations.filter((station) => station.stationType === StationType.mission)}
                             event={event!} onSubmit={handleUpdate}
                             isOperating={isOperating}
                         />
@@ -132,7 +132,7 @@ const ToolsPage: React.FC = (): React.JSX.Element => {
                         <Divider />
                         <RegisterPropertyPurchasesFormV3
                             teams={teams}
-                            stations={stations.filter((station) => station.stationType == StationType.mission)}
+                            stations={stations.filter((station) => station.stationType === StationType.mission)}
                             onSubmit={handleUpdate}
                             isOperating={isOperating}
                         />

--- a/src/app/events/v03/[eventCode]/operation/tools/page.tsx
+++ b/src/app/events/v03/[eventCode]/operation/tools/page.tsx
@@ -15,7 +15,7 @@ import InformationDialog from "@/components/composite/InformationDialog";
 import { ApplicationErrorFactory } from "@/error/applicationError";
 import { ApplicationErrorHandler } from "@/error/errorHandler";
 import { InitOperationResponse } from "@/features/init-operation/types";
-import { Events } from "@/generated/prisma";
+import { Events, StationType } from "@/generated/prisma";
 import { checkIsOperatingUser } from "@/lib/auth";
 import { UsersWithRelations } from "@/repositories/users/UsersRepository";
 import { TeamData } from "@/types/TeamData";
@@ -116,7 +116,11 @@ const ToolsPage: React.FC = (): React.JSX.Element => {
                 {/* メインコンテンツ */}
                 {!isLoading && !isInitDataLoading && !error && !contextError && (
                     <>
-                        <RegisterGoalStationsFormV3 stations={stations} event={event!} onSubmit={handleUpdate} isOperating={isOperating} />
+                        <RegisterGoalStationsFormV3
+                            stations={stations.filter((station) => station.stationType == StationType.mission)}
+                            event={event!} onSubmit={handleUpdate}
+                            isOperating={isOperating}
+                        />
                         <Divider />
                         <ArrivalGoalStationsFormV3 event={event} teams={teams} stations={stations} onSubmit={handleUpdate} isOperating={isOperating} />
                         <Divider />
@@ -126,7 +130,12 @@ const ToolsPage: React.FC = (): React.JSX.Element => {
                         <Divider />
                         <PointsTransferFormV3 teams={teams} onSubmit={handleUpdate} isOperating={isOperating} />
                         <Divider />
-                        <RegisterPropertyPurchasesFormV3 teams={teams} stations={stations} onSubmit={handleUpdate} isOperating={isOperating} />
+                        <RegisterPropertyPurchasesFormV3
+                            teams={teams}
+                            stations={stations.filter((station) => station.stationType == StationType.mission)}
+                            onSubmit={handleUpdate}
+                            isOperating={isOperating}
+                        />
                         <Divider />
                         <RegisterBombiiManualForm teams={teams} event={event!} onSubmit={handleUpdate} isOperating={isOperating} />
                         <Divider />

--- a/src/app/events/v03/[eventCode]/roulette/page.tsx
+++ b/src/app/events/v03/[eventCode]/roulette/page.tsx
@@ -131,7 +131,7 @@ const RoulettePage: React.FC = (): React.JSX.Element => {
                     <>
                         <Box sx={{ marginX: 2 }}>
                             <RouletteFormV3
-                                stations={stations.filter((station) => station.stationType == StationType.mission)}
+                                stations={stations.filter((station) => station.stationType === StationType.mission)}
                                 nearbyStations={nearbyStations}
                                 latestTransitStations={latestTransitStations}
                                 goalStations={goalStations}

--- a/src/app/events/v03/[eventCode]/roulette/page.tsx
+++ b/src/app/events/v03/[eventCode]/roulette/page.tsx
@@ -2,7 +2,7 @@
 
 import CustomButton from "@/components/base/CustomButton";
 import PageTitle from "@/components/base/PageTitle";
-import { GoalStations, LatestTransitStations } from "@/generated/prisma";
+import { GoalStations, LatestTransitStations, StationType } from "@/generated/prisma";
 import { ClosestStation } from "@/types/ClosestStation";
 import { CurrentLocationUtils } from "@/utils/currentLocationUtils";
 import { ArrowDropDown, Casino, Help } from "@mui/icons-material";
@@ -131,7 +131,7 @@ const RoulettePage: React.FC = (): React.JSX.Element => {
                     <>
                         <Box sx={{ marginX: 2 }}>
                             <RouletteFormV3
-                                stations={stations}
+                                stations={stations.filter((station) => station.stationType == StationType.mission)}
                                 nearbyStations={nearbyStations}
                                 latestTransitStations={latestTransitStations}
                                 goalStations={goalStations}

--- a/src/components/composite/form/RouletteFormV3.tsx
+++ b/src/components/composite/form/RouletteFormV3.tsx
@@ -65,6 +65,7 @@ const RouletteFormV3: React.FC<RouletteFormV3Props> = ({
      */
     const getWeightedStation = (): Stations | null => {
         const nextStationCode = RouletteUtils.getWeightedStationCodeV3(
+            stations,
             nearbyStations,
             latestTransitStations,
             goalStations,

--- a/src/utils/rouletteUtils.ts
+++ b/src/utils/rouletteUtils.ts
@@ -118,8 +118,7 @@ export class RouletteUtils {
      * @param latestTransitStations - 最新の経由駅情報
      * @param goalStations - 既出目的駅のリスト
      * @param startStationCode - 開始駅のコード
-     * @param eliminationTimeRangeMinutes - 選択肢から除外する時間範囲（分）
-     * @returns {StationsProbabilitiesMap} 駅ごとの確率を含むマップ
+     * @return {string} 次に選択する駅のコード
      */
     static getWeightedStationCodeV3(
         stations: Stations[],
@@ -143,6 +142,7 @@ export class RouletteUtils {
 
     /**
      * 候補駅を絞り込む（V3）
+     * @param stations - すべての駅情報
      * @param graph - グラフ形式の駅接続情報
      * @param startStationCode - 開始駅のコード
      * @param latestTransitStations - 最新の経由駅情報
@@ -158,6 +158,13 @@ export class RouletteUtils {
     ): DistancesMap {
         const distances: DistancesMap = DijkstraUtils.calculateRequiredTimeAndStations(graph, startStationCode);
 
+        // mission駅のstationCodeをSetに変換して高速検索可能にする
+        const missionStationCodes = new Set(
+            stations
+                .filter((station) => station.stationType === StationType.mission)
+                .map((station) => station.stationCode)
+        );
+
         // 候補駅のフィルタリング
         const filteredDistances: DistancesMap = new Map(
             [...distances].filter(([key]) => {
@@ -170,7 +177,7 @@ export class RouletteUtils {
                     // 既出目的地駅に含まれないこと（空配列の場合はすべて選択可能）
                     (goalStations.length === 0 || !goalStations.some((station) => station.stationCode === key)) &&
                     // 駅の種類がmissionであること
-                    stations.find((station) => station.stationCode === key)?.stationType === StationType.mission
+                    missionStationCodes.has(key)
                 );
             }),
         );

--- a/src/utils/rouletteUtils.ts
+++ b/src/utils/rouletteUtils.ts
@@ -1,4 +1,4 @@
-import { GoalStations, LatestTransitStations, Stations } from "@/generated/prisma";
+import { GoalStations, LatestTransitStations, Stations, StationType } from "@/generated/prisma";
 import { NearbyStationsWithRelations } from "@/repositories/nearbyStations/NearbyStationsRepository";
 import DijkstraUtils, { DistancesMap } from "./dijkstraUtils";
 import { StationsGraph, StationsProbabilitiesMap } from "./dijkstraUtils";
@@ -113,6 +113,7 @@ export class RouletteUtils {
     /**
      * 目的駅ルーレット（V3）
      * @description 開始駅からの距離に基づいて、次の目的駅を重み付きルーレットで選択する
+     * @param stations - すべての駅情報
      * @param nearbyStations - 近隣駅の接続情報
      * @param latestTransitStations - 最新の経由駅情報
      * @param goalStations - 既出目的駅のリスト
@@ -121,6 +122,7 @@ export class RouletteUtils {
      * @returns {StationsProbabilitiesMap} 駅ごとの確率を含むマップ
      */
     static getWeightedStationCodeV3(
+        stations: Stations[],
         nearbyStations: NearbyStationsWithRelations[],
         latestTransitStations: LatestTransitStations[] = [],
         goalStations: GoalStations[] = [],
@@ -128,6 +130,7 @@ export class RouletteUtils {
     ): string {
         const graph: StationsGraph = DijkstraUtils.convertNearbyStationsToStationGraph(nearbyStations);
         const distances: DistancesMap = this.getCandidateStationDistancesV3(
+            stations,
             graph,
             startStationCode,
             latestTransitStations,
@@ -147,6 +150,7 @@ export class RouletteUtils {
      * @return {DistancesMap} 絞り込み済みの候補駅のコードとその駅までの時間と駅数を含むマップ
      */
     static getCandidateStationDistancesV3(
+        stations: Stations[],
         graph: StationsGraph,
         startStationCode: string,
         latestTransitStations: LatestTransitStations[] = [],
@@ -164,7 +168,9 @@ export class RouletteUtils {
                     (latestTransitStations.length === 0 ||
                         !latestTransitStations.some((station) => station.stationCode === key)) &&
                     // 既出目的地駅に含まれないこと（空配列の場合はすべて選択可能）
-                    (goalStations.length === 0 || !goalStations.some((station) => station.stationCode === key))
+                    (goalStations.length === 0 || !goalStations.some((station) => station.stationCode === key)) &&
+                    // 駅の種類がmissionであること
+                    stations.find((station) => station.stationCode === key)?.stationType === StationType.mission
                 );
             }),
         );


### PR DESCRIPTION
### ◯概要

目的駅ルーレットの候補をミッション駅のみに絞る

### ◯詳細

- 目的駅ルーレットの候補をミッション駅のみに絞る

### ◯追加対応

- 目的駅登録フォームの選択肢をmissionのみにする
- 物件駅購入フォームの選択肢をmissionのみにする