### PR TITLE
[TSK-75] チームカードの金銭表示を持ち金にする

### DIFF
--- a/src/components/base/TeamCardV3.tsx
+++ b/src/components/base/TeamCardV3.tsx
@@ -140,7 +140,7 @@ export const TeamCardV3: React.FC<TeamCardV3Props> = ({
                         >
                             <Grid size={4}>
                                 <Typography variant="body2">
-                                    <strong>総資産</strong>
+                                    <strong>持ち金</strong>
                                 </Typography>
                             </Grid>
                             <Grid size={8}>


### PR DESCRIPTION
### ◯概要

チームカードの金銭表示を持ち金にする

### ◯詳細

- チームカードの金銭表示を「総資産」から「持ち金」にする
- 計算される金額からproperyを除外する
    →もともと考慮済み。propertyの場合マイナスでデータが登録されるので、むしろ持ち金の表示部にはpropertyを加算しないといけない。