### PR TITLE
[TSK-57] 連続ゴールボーナスの判定処理の実装

### DIFF
--- a/prisma/migrations/20260627094410_tsk_57_consecutive_goal_bonus/migration.sql
+++ b/prisma/migrations/20260627094410_tsk_57_consecutive_goal_bonus/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "transit_stations" ADD COLUMN     "is_goal" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -222,6 +222,7 @@ model TransitStations {
   stationCode String   @map("station_code")
   teamCode    String   @map("team_code")
   eventCode   String   @map("event_code")
+  isGoal      Boolean  @default(false) @map("is_goal")
   createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(3)
   event       Events   @relation(fields: [eventCode], references: [eventCode])

--- a/src/components/composite/form/ArrivalGoalStationsFormV3.tsx
+++ b/src/components/composite/form/ArrivalGoalStationsFormV3.tsx
@@ -190,7 +190,9 @@ const ArrivalGoalStationsFormV3: React.FC<ArrivalGoalStationsFormV3Props> = ({
                 `賞金: ${Converter.convertPointsToYenV3(responseArrivalData.points)}\n` +
                 `物件駅購入: ${willBuyStationInput === WillBuyStation.YES
                     ? stationName + "駅 : " + Converter.convertPointsToYenV3(responseArrivalData.purchasePoints ?? 0) + "円"
-                    : "しない"}`;
+                    : "しない"}\n` +
+                `連続ゴール数: ${responseArrivalData.consecutiveGoalCounts}回\n` +
+                `連続ゴールボーナス: ${Converter.convertPointsToYenV3(responseArrivalData.consecutiveGoalBonus ?? 0)}` + "円";
             await showAlertDialog({
                 title: DialogConstants.TITLE.REGISTERED,
                 message: completionMessage,

--- a/src/constants/gameConstants.ts
+++ b/src/constants/gameConstants.ts
@@ -123,6 +123,10 @@ export const GameConstants = {
         /** 駅数ごとの増加額(万円) */
         INCREMENT_PER_STATION_NUMBER: 1_000,
     } as const,
+
+    // TODO 連続ゴールボーナスに使用する定数は暫定。ゲームバランスを見ながら調整する。
+    /** 連続ゴールボーナスに使用する定数 */
+    CONSECUTIVE_GOAL_BONUS_PER_STATION_NUMBER: 1_000,
 } as const;
 
 export type GameConstants = typeof GameConstants;

--- a/src/features/arrival-goal-station-v3/service.ts
+++ b/src/features/arrival-goal-station-v3/service.ts
@@ -14,13 +14,19 @@ export const ArrivalGoalStationV3ServiceImpl: ArrivalGoalStationV3Service = {
      * @return {Promise<PostArrivalGoalStationV3Response>} レスポンス
      */
     async postArrivalGoalStationV3(req: PostArrivalGoalStationV3Request): Promise<PostArrivalGoalStationV3Response> {
-        const [nearbyStationsRepository, goalStationsRepository, pointsRepository, propertyPurchasesRepository] =
-            await Promise.all([
-                RepositoryFactory.getNearbyStationsRepository(),
-                RepositoryFactory.getGoalStationsRepository(),
-                RepositoryFactory.getPointsRepository(),
-                RepositoryFactory.getPropertyPurchasesRepository(),
-            ]);
+        const [
+            nearbyStationsRepository,
+            goalStationsRepository,
+            pointsRepository,
+            propertyPurchasesRepository,
+            transitStationsRepository,
+        ] = await Promise.all([
+            RepositoryFactory.getNearbyStationsRepository(),
+            RepositoryFactory.getGoalStationsRepository(),
+            RepositoryFactory.getPointsRepository(),
+            RepositoryFactory.getPropertyPurchasesRepository(),
+            RepositoryFactory.getTransitStationsRepository(),
+        ]);
 
         try {
             let latestGoalStationGrade: StationGrade | null = null;
@@ -42,6 +48,9 @@ export const ArrivalGoalStationV3ServiceImpl: ArrivalGoalStationV3Service = {
                 });
             }
 
+            // 最新の経由駅を取得
+            const latestTransitStation = await transitStationsRepository.findLatestByTeamCode(req.teamCode);
+
             const nearbyStations = await nearbyStationsRepository.findByEventTypeCode(req.eventTypeCode);
 
             // ポイント計算
@@ -51,8 +60,20 @@ export const ArrivalGoalStationV3ServiceImpl: ArrivalGoalStationV3Service = {
                 latestGoalStationCode,
             );
 
+            // 連続ゴールボーナス計算
+            const transitStations = await transitStationsRepository.findGoalStationsByEventCode(req.eventCode);
+            let consecutiveGoalCount = 0;
+            for (const transitStation of transitStations) {
+                if (transitStation.teamCode === req.teamCode) {
+                    consecutiveGoalCount++;
+                } else {
+                    break;
+                }
+            }
+            const consecutiveGoalBonus = GameLogicUtils.calculateConsecutiveGoalBonusV3(consecutiveGoalCount);
+
             // DB登録処理
-            const { createdPoints, createdPropertyPurchases, createdPurchasePoints } =
+            const { createdPoints, createdGoalBonusPoints, createdPropertyPurchases, createdPurchasePoints } =
                 await RepositoryFactory.withTransaction(async (tx) => {
                     // E01: 購入済みチェック
                     if (req.willPurchase) {
@@ -76,7 +97,7 @@ export const ArrivalGoalStationV3ServiceImpl: ArrivalGoalStationV3Service = {
                             tx,
                         );
                         const price = GameConstants.STATION_GRADE[latestGoalStationGrade ?? StationGrade.none].price;
-                        if (currentPoints + arrivalPoints - price < 0) {
+                        if (currentPoints + arrivalPoints + consecutiveGoalBonus - price < 0) {
                             throw new BadRequestError({
                                 errorCode: VerifyArrivalGoalStationV3Result.E02_INSUFFICIENT_POINTS,
                             });
@@ -89,6 +110,28 @@ export const ArrivalGoalStationV3ServiceImpl: ArrivalGoalStationV3Service = {
                         req.teamCode,
                         arrivalPoints,
                         GameConstants.POINT_STATUS.SCORED,
+                        tx,
+                    );
+
+                    // 連続ゴールボーナス加算
+                    const createdGoalBonusPoints = await (async () => {
+                        if (consecutiveGoalBonus > 0) {
+                            return await pointsRepository.create(
+                                req.eventCode,
+                                req.teamCode,
+                                consecutiveGoalBonus,
+                                GameConstants.POINT_STATUS.SCORED,
+                                tx,
+                            );
+                        }
+                    })();
+
+                    // 最新の経由駅のゴール判定フラグを更新
+                    await transitStationsRepository.update(
+                        latestTransitStation?.id ?? 0,
+                        {
+                            isGoal: true,
+                        },
                         tx,
                     );
 
@@ -111,15 +154,27 @@ export const ArrivalGoalStationV3ServiceImpl: ArrivalGoalStationV3Service = {
                             GameConstants.POINT_STATUS.PROPERTY,
                             tx,
                         );
-                        return { createdPoints, createdPropertyPurchases, createdPurchasePoints };
+                        return {
+                            createdPoints,
+                            createdGoalBonusPoints,
+                            createdPropertyPurchases,
+                            createdPurchasePoints,
+                        };
                     }
-                    return { createdPoints, createdPropertyPurchases: null, createdPurchasePoints: null };
+                    return {
+                        createdPoints,
+                        createdGoalBonusPoints,
+                        createdPropertyPurchases: null,
+                        createdPurchasePoints: null,
+                    };
                 });
 
             const res: PostArrivalGoalStationV3Response = {
                 points: createdPoints.points,
                 propertyPurchases: createdPropertyPurchases,
                 purchasePoints: createdPurchasePoints?.points ?? null,
+                consecutiveGoalCounts: consecutiveGoalCount,
+                consecutiveGoalBonus: createdGoalBonusPoints?.points ?? null,
             };
             return res;
         } catch (error) {

--- a/src/features/arrival-goal-station-v3/types.ts
+++ b/src/features/arrival-goal-station-v3/types.ts
@@ -18,10 +18,16 @@ export type PostArrivalGoalStationV3Request = {
 
 /**
  * 目的駅到着処理（V3）のレスポンス
- * @property { TransitStations } transitStation - 登録された経由駅
+ * @property { number } points - ポイント
+ * @property { PropertyPurchases | null } propertyPurchases - 物件購入情報
+ * @property { number | null } purchasePoints - 購入ポイント
+ * @property { number } consecutiveGoalCounts - 連続ゴール数
+ * @property { number } consecutiveGoalBonus - 連続ゴールボーナス
  */
 export type PostArrivalGoalStationV3Response = {
     points: number;
     propertyPurchases: PropertyPurchases | null;
     purchasePoints: number | null;
+    consecutiveGoalCounts: number;
+    consecutiveGoalBonus: number | null;
 };

--- a/src/features/arrival-goal-station-v3/validator.ts
+++ b/src/features/arrival-goal-station-v3/validator.ts
@@ -19,4 +19,6 @@ export const PostArrivalGoalStationV3ResponseSchema = z.object({
     points: z.number(),
     propertyPurchases: PropertyPurchasesSchema.nullable(),
     purchasePoints: z.number().nullable(),
+    consecutiveGoalCounts: z.number(),
+    consecutiveGoalBonus: z.number().nullable(),
 });

--- a/src/features/verify/verify-arrival-goal-station-v3/service.ts
+++ b/src/features/verify/verify-arrival-goal-station-v3/service.ts
@@ -64,6 +64,18 @@ export const VerifyArrivalGoalStationV3ServiceImpl: VerifyArrivalGoalStationV3Se
                 latestGoalStationCode,
             );
 
+            // 連続ゴールボーナス計算
+            const transitStations = await transitStationsRepository.findGoalStationsByEventCode(req.eventCode);
+            let consecutiveGoalCount = 0;
+            for (const transitStation of transitStations) {
+                if (transitStation.teamCode === req.teamCode) {
+                    consecutiveGoalCount++;
+                } else {
+                    break;
+                }
+            }
+            const consecutiveGoalBonus = GameLogicUtils.calculateConsecutiveGoalBonusV3(consecutiveGoalCount);
+
             // 最新の経由駅コード
             const latestTransitStationCode = await transitStationsRepository
                 .findLatestByTeamCode(req.teamCode)
@@ -89,7 +101,7 @@ export const VerifyArrivalGoalStationV3ServiceImpl: VerifyArrivalGoalStationV3Se
             }
 
             // ポイント不足エラー
-            const hasSufficientPoints = req.willPurchase && (points + arrivalPoints - price < 0);
+            const hasSufficientPoints = req.willPurchase && points + arrivalPoints + consecutiveGoalBonus - price < 0;
             if (hasSufficientPoints) {
                 throw new BadRequestError({
                     errorCode: VerifyArrivalGoalStationV3Result.E02_INSUFFICIENT_POINTS,

--- a/src/repositories/transitStations/TransitStationsRepository.ts
+++ b/src/repositories/transitStations/TransitStationsRepository.ts
@@ -71,6 +71,27 @@ export class TransitStationsRepository extends BaseRepository {
     }
 
     /**
+     * 指定されたイベントコードに紐づくゴール判定フラグがtrueの経由駅を取得
+     * @param eventCode - イベントコード
+     * @returns {Promise<TransitStations[]>} ゴール駅の経由駅の配列
+     */
+    async findGoalStationsByEventCode(eventCode: string): Promise<TransitStations[]> {
+        try {
+            return (await this.prisma.transitStations.findMany({
+                where: {
+                    eventCode: eventCode,
+                    isGoal: true,
+                },
+                orderBy: {
+                    id: "desc",
+                },
+            })) as TransitStations[];
+        } catch (error) {
+            this.handleDatabaseError(error, "findGoalStationsByEventCode");
+        }
+    }
+
+    /**
      * IDで経由駅を取得
      * @param id - 経由駅ID
      * @returns {Promise<TransitStationsWithRelations | null>} 経由駅情報またはnull
@@ -134,6 +155,35 @@ export class TransitStationsRepository extends BaseRepository {
             return result.count;
         } catch (error) {
             this.handleDatabaseError(error, "createMany");
+        }
+    }
+
+    /**
+     * 指定されたIDの経由駅を更新
+     * @param id - 更新対象のID
+     * @param transitStationData - 更新データ
+     * @returns {Promise<TransitStations>} 更新された経由駅
+     */
+    async update(
+        id: number,
+        transitStationData: {
+            stationCode?: string;
+            eventCode?: string;
+            teamCode?: string;
+            isGoal?: boolean;
+        },
+        tx?: PrismaTransactionClient,
+    ): Promise<TransitStations> {
+        const client = tx ?? this.prisma;
+        try {
+            return await client.transitStations.update({
+                where: {
+                    id: id,
+                },
+                data: transitStationData,
+            });
+        } catch (error) {
+            this.handleDatabaseError(error, "update");
         }
     }
 

--- a/src/utils/gameLogicUtils.ts
+++ b/src/utils/gameLogicUtils.ts
@@ -65,4 +65,15 @@ export class GameLogicUtils {
             remainingStationsNumber * GameConstants.ARRIVAL_PRIZE_V3.INCREMENT_PER_STATION_NUMBER;
         return prize;
     }
+
+    /**
+     * 連続ゴールボーナスを計算する(V3)
+     * @param {number} consecutiveGoalCount - 連続ゴール数
+     * @returns {number} 連続ゴールボーナス
+     */
+    static calculateConsecutiveGoalBonusV3(consecutiveGoalCount: number): number {
+        return consecutiveGoalCount === 0
+            ? 0
+            : GameConstants.CONSECUTIVE_GOAL_BONUS_PER_STATION_NUMBER * (consecutiveGoalCount + 1);
+    }
 }


### PR DESCRIPTION
### ◯概要

連続でゴールした場合、ボーナスで賞金が加算されるので、連続ゴールかどうかを判定し、その回数に応じて賞金を設定する

### ◯詳細

- 到着フォーム送信時にその駅が目的地だった場合、画面に表示されるゴールのフィードバックに、連続回数情報と賞金金額を表示する。