### PR TITLE
[TSK-82] 目的駅選択ロジックの改善

### DIFF
--- a/__tests__/roulette-weighted-station.test.ts
+++ b/__tests__/roulette-weighted-station.test.ts
@@ -9,6 +9,7 @@
  *
  * 使い方:
  *   npx dotenv -e .env.local -- npx jest __tests__/roulette-weighted-station.test.ts
+ *   npx dotenv -e .env.local -- node --inspect-brk ./node_modules/jest/bin/jest.js __tests__/roulette-weighted-station.test.ts --runInBand
  *
  * 設定:
  *   EVENT_TYPE_CODE: イベント種別コード
@@ -17,7 +18,7 @@
  *  ELIMINATION_TIME_RANGE_MINUTES: 除外する時間範囲（分）。この値以下の駅は候補から除外
  */
 
-import { PrismaClient, Stations, LatestTransitStations } from "@/generated/prisma";
+import { PrismaClient, Stations, LatestTransitStations, StationType } from "@/generated/prisma";
 import { NearbyStationsWithRelations } from "@/repositories/nearbyStations/NearbyStationsRepository";
 import DijkstraUtils, { DistancesMap, StationsGraph } from "@/utils/dijkstraUtils";
 import { RouletteUtils } from "@/utils/rouletteUtils";
@@ -29,6 +30,8 @@ const EVENT_TYPE_CODE = "METRO_V1"; // イベント種別コード
 const START_STATION_CODE = "METRO_V1_OTEMACHI"; // 開始駅コード
 const VERSION: "v2" | "v3" = "v3"; // ルーレットロジックのバージョン選択（v2: 旧ロジック, v3: 新ロジック）
 const ELIMINATION_TIME_RANGE_MINUTES = 10; // 除外する時間範囲（分）。この値以下の駅は候補から除外
+const SET_COUNT = 20; // セット数
+const RUNS_PER_SET = 15; // 各セットの実行回数
 // ==========================
 
 // テスト用の型定義
@@ -212,7 +215,9 @@ describe("RouletteUtils getWeightedStationCode テスト", () => {
             dbConnected = false;
             console.error("Database connection failed:", error);
             // DATABASE_URLが設定されていない場合は、テストをスキップ
-            console.warn("Skipping test: DATABASE_URL environment variable not set. Please set it and run: npx dotenv -e .env.local -- npx jest");
+            console.warn(
+                "Skipping test: DATABASE_URL environment variable not set. Please set it and run: npx dotenv -e .env.local -- npx jest",
+            );
         }
     });
 
@@ -220,7 +225,7 @@ describe("RouletteUtils getWeightedStationCode テスト", () => {
         await prisma.$disconnect();
     });
 
-    test("指定駅から10回✕20セットのルーレットテスト", () => {
+    test(`指定駅から${SET_COUNT}回✕${RUNS_PER_SET}セットのルーレットテスト`, () => {
         if (!dbConnected || stations.length === 0 || nearbyStations.length === 0) {
             console.warn("Test skipped: Database connection failed or no data retrieved");
             return;
@@ -230,16 +235,22 @@ describe("RouletteUtils getWeightedStationCode テスト", () => {
         const setResultsArray: RouletteTestResult[][] = []; // CSV出力用にセット別データを保持
         const stationFrequency = new Map<string, number>();
 
-        // 20セットの実行
-        for (let setIndex = 0; setIndex < 20; setIndex++) {
+        // セットの実行
+        for (let setIndex = 0; setIndex < SET_COUNT; setIndex++) {
             const setResults: RouletteTestResult[] = [];
+            const selectedStationsSet = new Set<string>();
             let currentStationCode = START_STATION_CODE; // 開始駅から開始
 
-            // 各セットで10回実行
-            for (let i = 0; i < 10; i++) {
+            // 各セットで指定回数実行
+            for (let i = 0; i < RUNS_PER_SET; i++) {
                 const selectedStationCode =
                     VERSION === "v3"
                         ? RouletteUtils.getWeightedStationCodeV3(
+                              stations.filter(
+                                  (station) =>
+                                      station.stationType === StationType.mission &&
+                                      selectedStationsSet.has(station.stationCode) === false,
+                              ),
                               nearbyStations,
                               latestTransitStations,
                               goalStations,
@@ -279,6 +290,7 @@ describe("RouletteUtils getWeightedStationCode テスト", () => {
                     // 駅の出現頻度をカウント
                     const count = stationFrequency.get(selectedStation.stationCode) || 0;
                     stationFrequency.set(selectedStation.stationCode, count + 1);
+                    selectedStationsSet.add(selectedStation.stationCode);
                 }
             }
 
@@ -316,7 +328,7 @@ describe("RouletteUtils getWeightedStationCode テスト", () => {
         console.log(`CSV出力完了: ${csvFilePath}`);
 
         // アサーション（テストが実行されたことを確認）
-        expect(finalStats.totalRuns).toBe(200);
+        expect(finalStats.totalRuns).toBe(SET_COUNT * RUNS_PER_SET);
         expect(finalStats.stationFrequency.size).toBeGreaterThan(0);
         expect(finalStats.averageStations).toBeGreaterThan(0);
         expect(finalStats.averageTime).toBeGreaterThan(0);

--- a/src/constants/gameConstants.ts
+++ b/src/constants/gameConstants.ts
@@ -83,6 +83,11 @@ export const GameConstants = {
     CANDIDATE_END_STATIONS_NUM: 1,
 
     /**
+     * 目的駅候補の最小距離（駅数）
+     */
+    MIN_CANDIDATE_END_STATION_DISTANCE: 7,
+
+    /**
      * 端駅の駅コード（V3）
      * NOTE 実装コストを考慮しコード側で定数として持つ。将来的にDBから取得するように変更する可能性あり。
      */

--- a/src/constants/gameConstants.ts
+++ b/src/constants/gameConstants.ts
@@ -58,22 +58,50 @@ export const GameConstants = {
     ELIMINATION_TIME_RANGE_MINUTES: 15,
 
     // ========== V3 ==========
-    // TODO 所要時間の上限と、そのバケットに入る駅の数は暫定。ゲームバランスを見ながら調整する。
+    // TODO 所要時間で昇順ソートしたときの上位%と、そのバケットに入る駅の数は暫定。ゲームバランスを見ながら調整する。
     /**
-     * 目的駅選択のバケット設定（所要時間の上限と、そのバケットに入る駅の数）
-     * @property {number} maxMinutes バケットに入る駅の所要時間の上限(分)
+     * 目的駅選択のバケット設定（所要時間で昇順ソートしたときの上位%と、そのバケットに入る駅の数）
+     * @property {number} percentile 所要時間で昇順ソートしたときの上位%
      * @property {number} count バケットに入る駅の数
-     * */
-    STATION_SELECTION_BUCKETS: [
-        { maxMinutes: 5, count: 0 },
-        { maxMinutes: 10, count: 0 },
-        { maxMinutes: 15, count: 0 },
-        { maxMinutes: 20, count: 0 },
-        { maxMinutes: 25, count: 32 },
-        { maxMinutes: 30, count: 4 },
-        { maxMinutes: 35, count: 2 },
-        { maxMinutes: 40, count: 1 },
-        { maxMinutes: Infinity, count: 1 },
+     */
+    STATION_SELECTION_RATIO_BUCKETS: [
+        { percentile: 10, count: 0 },
+        { percentile: 20, count: 0 },
+        { percentile: 30, count: 0 },
+        { percentile: 40, count: 0 },
+        { percentile: 50, count: 0 },
+        { percentile: 60, count: 1 },
+        { percentile: 70, count: 1 },
+        { percentile: 80, count: 2 },
+        { percentile: 90, count: 2 },
+        { percentile: 100, count: 1 },
+    ] as const,
+
+    /**
+     * 端駅からランダムに選択する駅の数
+     */
+    CANDIDATE_END_STATIONS_NUM: 1,
+
+    /**
+     * 端駅の駅コード（V3）
+     * NOTE 実装コストを考慮しコード側で定数として持つ。将来的にDBから取得するように変更する可能性あり。
+     */
+    END_STATION_CODES_V3: [
+        "METRO_V1_AKABANE-IWABUCHI",
+        "METRO_V1_OGIKUBO",
+        "METRO_V1_KITA-AYASE",
+        "METRO_V1_SHIN-KIBA",
+        "METRO_V1_NAKANO",
+        "METRO_V1_NAKA-MEGURO",
+        "METRO_V1_NISHI-TAKASHIMADAIRA",
+        "METRO_V1_NISHI-FUNABASHI",
+        "METRO_V1_NISHI-MAGOME",
+        "METRO_V1_HIKARIGAOKA",
+        "METRO_V1_HONANCHO",
+        "METRO_V1_MEGURO",
+        "METRO_V1_MOTOYAWATA",
+        "METRO_V1_YOYOGI-UEHARA",
+        "METRO_V1_WAKOSHI",
     ] as const,
 
     // TODO 駅グレードの価格設定は暫定。ゲームバランスを見ながら調整する。

--- a/src/utils/rouletteUtils.ts
+++ b/src/utils/rouletteUtils.ts
@@ -227,7 +227,7 @@ export class RouletteUtils {
 
         // 端駅からランダムに駅を選択して追加
         const selectedEdgeStations = endStationsDistances
-            .filter(([_, { stationsNumber }]) => stationsNumber >= 7) // 7マス以上離れた端駅のみを対象
+            .filter(([_, { stationsNumber }]) => stationsNumber >= GameConstants.MIN_CANDIDATE_END_STATION_DISTANCE) // 7マス以上離れた端駅のみを対象
             .sort(() => 0.5 - Math.random())
             .slice(0, GameConstants.CANDIDATE_END_STATIONS_NUM)
             .map(([stationCode]) => stationCode);
@@ -235,10 +235,13 @@ export class RouletteUtils {
 
         // 候補駅の数が少ない場合、7マス以上離れたすべての駅を均等な確率で選択する
         if (selectedStations.length < 5) {
-            distances.forEach(({ stationsNumber }, stationCode) => {
-                if (stationsNumber >= 7) {
-                    stationsProbabilities.set(stationCode, 1 / distances.size);
-                }
+            const filteredDistances = new Map(
+                [...distances].filter(
+                    ([_, { stationsNumber }]) => stationsNumber >= GameConstants.MIN_CANDIDATE_END_STATION_DISTANCE,
+                ),
+            );
+            filteredDistances.forEach((_, stationCode) => {
+                stationsProbabilities.set(stationCode, 1 / filteredDistances.size);
             });
             return stationsProbabilities;
         }

--- a/src/utils/rouletteUtils.ts
+++ b/src/utils/rouletteUtils.ts
@@ -162,7 +162,7 @@ export class RouletteUtils {
         const missionStationCodes = new Set(
             stations
                 .filter((station) => station.stationType === StationType.mission)
-                .map((station) => station.stationCode)
+                .map((station) => station.stationCode),
         );
 
         // 候補駅のフィルタリング
@@ -193,24 +193,52 @@ export class RouletteUtils {
         // 確率を格納するマップを初期化
         const stationsProbabilities: StationsProbabilitiesMap = new Map<string, number>();
 
-        let prevMax = 0;
+        // 所要時間の昇順でソート
+        const sortedDistances = [...distances].sort((a, b) => a[1].timeMinutes - b[1].timeMinutes);
+
+        // 端駅のコードリスト
+        const endStationCodes = new Set<string>(GameConstants.END_STATION_CODES_V3);
+        // 端駅のマップ
+        const endStationsDistances = sortedDistances.filter(([stationCode]) => endStationCodes.has(stationCode));
+        // 非端駅のマップ
+        const nonEndStationsDistances = sortedDistances.filter(([stationCode]) => !endStationCodes.has(stationCode));
+
+        // 現在のバケットの開始インデックス
+        let prevIndex = 0;
+        // 選択された最終候補駅の駅コードリスト
         const selectedStations: string[] = [];
-        for (const bucket of GameConstants.STATION_SELECTION_BUCKETS) {
-            const candidateStations = [...distances].filter(
-                ([_, { timeMinutes }]) => timeMinutes > prevMax && timeMinutes <= bucket.maxMinutes,
-            );
+        for (const bucket of GameConstants.STATION_SELECTION_RATIO_BUCKETS) {
+            // 上位N%までのインデックスを算出
+            const endIndex = Math.ceil((bucket.percentile / 100) * nonEndStationsDistances.length);
+            if (bucket.count === 0) {
+                prevIndex = endIndex;
+                continue; // バケットから選出される駅の数が0の場合はスキップ
+            }
+            // 上位N%にあたる候補駅を取得
+            const candidateStations = nonEndStationsDistances.slice(prevIndex, endIndex);
+            // 候補駅からランダムに指定された数の駅を選択
             const selectedInBucket = candidateStations
                 .sort(() => 0.5 - Math.random())
                 .slice(0, bucket.count)
                 .map(([stationCode]) => stationCode);
             selectedStations.push(...selectedInBucket);
-            prevMax = bucket.maxMinutes;
+            prevIndex = endIndex;
         }
 
-        // 候補駅の数が少ない場合、すべての駅を均等な確率で選択する
+        // 端駅からランダムに駅を選択して追加
+        const selectedEdgeStations = endStationsDistances
+            .filter(([_, { stationsNumber }]) => stationsNumber >= 7) // 7マス以上離れた端駅のみを対象
+            .sort(() => 0.5 - Math.random())
+            .slice(0, GameConstants.CANDIDATE_END_STATIONS_NUM)
+            .map(([stationCode]) => stationCode);
+        selectedStations.push(...selectedEdgeStations);
+
+        // 候補駅の数が少ない場合、7マス以上離れたすべての駅を均等な確率で選択する
         if (selectedStations.length < 5) {
-            distances.forEach((_, stationCode) => {
-                stationsProbabilities.set(stationCode, 1 / distances.size);
+            distances.forEach(({ stationsNumber }, stationCode) => {
+                if (stationsNumber >= 7) {
+                    stationsProbabilities.set(stationCode, 1 / distances.size);
+                }
             });
             return stationsProbabilities;
         }

--- a/tools/roulette-probability-analyzer/probabilities.ts
+++ b/tools/roulette-probability-analyzer/probabilities.ts
@@ -51,7 +51,6 @@ function calculateProbabilitiesFromStationV3(
     graph: StationsGraph,
     startStationCode: string,
 ): StationsProbabilitiesMap {
-    RouletteUtils.getCandidateStationDistancesV3(stations, graph, startStationCode, [], []);
     return RouletteUtils.calculateProbabilitiesV3(
         RouletteUtils.getCandidateStationDistancesV3(stations, graph, startStationCode, [], []),
     );

--- a/tools/roulette-probability-analyzer/probabilities.ts
+++ b/tools/roulette-probability-analyzer/probabilities.ts
@@ -46,7 +46,11 @@ function calculateProbabilitiesFromStation(graph: StationsGraph, startStationCod
     );
 }
 
-function calculateProbabilitiesFromStationV3(stations: Stations[], graph: StationsGraph, startStationCode: string): StationsProbabilitiesMap {
+function calculateProbabilitiesFromStationV3(
+    stations: Stations[],
+    graph: StationsGraph,
+    startStationCode: string,
+): StationsProbabilitiesMap {
     RouletteUtils.getCandidateStationDistancesV3(stations, graph, startStationCode, [], []);
     return RouletteUtils.calculateProbabilitiesV3(
         RouletteUtils.getCandidateStationDistancesV3(stations, graph, startStationCode, [], []),
@@ -56,7 +60,12 @@ function calculateProbabilitiesFromStationV3(stations: Stations[], graph: Statio
 /**
  * ① 単一駅起点モード: 指定駅からの各候補駅の出現確率を表示
  */
-function runSingleMode(stations: Stations[], graph: StationsGraph, startStationCode: string, stationMap: Map<string, StationInfo>) {
+function runSingleMode(
+    stations: Stations[],
+    graph: StationsGraph,
+    startStationCode: string,
+    stationMap: Map<string, StationInfo>,
+) {
     const startName = stationMap.get(startStationCode)?.name ?? startStationCode;
     const probabilities =
         VERSION === "v3"
@@ -233,10 +242,16 @@ async function main() {
     console.log("=".repeat(86));
 
     // 1. 駅マスタを取得
-    const stations = await prisma.stations.findMany({
-        where: { eventTypeCode: EVENT_TYPE_CODE },
-        orderBy: { kana: "asc" },
-    });
+    const stations =
+        VERSION === "v3"
+            ? await prisma.stations.findMany({
+                  where: { eventTypeCode: EVENT_TYPE_CODE },
+                  orderBy: { kana: "asc" },
+              })
+            : await prisma.stations.findMany({
+                  where: { eventTypeCode: EVENT_TYPE_CODE, stationType: "mission" },
+                  orderBy: { kana: "asc" },
+              });
 
     const stationMap = new Map<string, StationInfo>();
     stations.forEach((s) => {


### PR DESCRIPTION
### **◯概要**

目的駅の選択ロジックを、固定時間バケット方式から、移動時間でソートした候補駅を上位%でグループ分けする方式に変更する。

### ◯要件

- 端駅を別枠でグループ分けする
- 所要時間でソートして、上位からの割合ごとにグループ分けする