### PR TITLE
[TSK-86] 連続ゴールボーナスの事前チェックの判定不具合修正

### DIFF
--- a/src/features/verify/verify-arrival-goal-station-v3/service.ts
+++ b/src/features/verify/verify-arrival-goal-station-v3/service.ts
@@ -66,7 +66,7 @@ export const VerifyArrivalGoalStationV3ServiceImpl: VerifyArrivalGoalStationV3Se
 
             // 連続ゴールボーナス計算
             const transitStations = await transitStationsRepository.findGoalStationsByEventCode(req.eventCode);
-            let consecutiveGoalCount = 0;
+            let consecutiveGoalCount = 1;
             for (const transitStation of transitStations) {
                 if (transitStation.teamCode === req.teamCode) {
                     consecutiveGoalCount++;

--- a/src/utils/gameLogicUtils.ts
+++ b/src/utils/gameLogicUtils.ts
@@ -72,7 +72,7 @@ export class GameLogicUtils {
      * @returns {number} 連続ゴールボーナス
      */
     static calculateConsecutiveGoalBonusV3(consecutiveGoalCount: number): number {
-        return consecutiveGoalCount === 1
+        return consecutiveGoalCount <= 1
             ? 0
             : GameConstants.CONSECUTIVE_GOAL_BONUS_PER_STATION_NUMBER * (consecutiveGoalCount + 1);
     }


### PR DESCRIPTION
### **◯概要**

目的地到着処理の事前チェック処理における連続ゴール回数の判定の不具合の修正

### ◯詳細

この時点ではまだis_goalはtrueになっておらず、それを見越した数字にしなければならないので、consecutiveGoalCountは1で初期化する必要がある。

https://github.com/wist6ri4-org/realmomotetsu-v2/blob/040f13e87bd0c3a54e4651af2378b83e61e2c0d3/src/features/verify/verify-arrival-goal-station-v3/service.ts#L67-L76