### PR TITLE
[TSK-79] 自チーム所有物件駅の収益追加不具合修正

### DIFF
--- a/src/features/current-location-v3/service.ts
+++ b/src/features/current-location-v3/service.ts
@@ -82,7 +82,7 @@ export const CurrentLocationV3ServiceImpl: CurrentLocationV3Service = {
                     // ミッション駅/物件駅の場合
                     case StationType.mission: {
                         // 購入済みの物件駅の場合
-                        if (propertyPurchase) {
+                        if (propertyPurchase && propertyPurchase.teamCode != req.teamCode) {
                             // ポイント登録
                             const revenue =
                                 GameConstants.STATION_GRADE[propertyPurchase.station.stationGrade ?? StationGrade.none]


### PR DESCRIPTION
### **◯概要**
自チームが所有している物件駅に止まった際にも収益が加算される不具合の修正

### ◯要件
- 自チームが所有している物件駅に止まった際は収益が加算されず、discordの通知もされないこと